### PR TITLE
skip done if missing attachments

### DIFF
--- a/src/ws.message.ts
+++ b/src/ws.message.ts
@@ -240,7 +240,9 @@ export class WsMessage {
 
   private done(message: any) {
     const { content, id, attachments, components, flags } = message;
-    console.log("components=====", JSON.stringify(components));
+    if(!attachments.length) {
+      return
+    }
     const MJmsg: MJMessage = {
       id,
       flags,


### PR DESCRIPTION
When requesting variations or upscales I get an empty attachments array which leads to a crash in this function.
I added a simple safeguard to prevent this