### PR TITLE
Fix the problem of not returning finished image

### DIFF
--- a/src/discord.ws.ts
+++ b/src/discord.ws.ts
@@ -176,7 +176,7 @@ export class WsMessage {
       }
     }
 
-    if (!nonce && attachments?.length > 0 && components?.length > 0) {
+    if (nonce && attachments?.length > 0 && components?.length > 0) {
       this.done(message);
       return;
     }


### PR DESCRIPTION
Problem root casue:
1. Discord message doesn't contain progress = done any more
2. Once message been finished a new message will be created, but nonce is not null, so it will not go with the done process

Solution:
change the condition of  nonce